### PR TITLE
Add AI skills to homepage

### DIFF
--- a/flux/clusters/homelab/infrastructure/homepage/frontend/src/pages/Home.tsx
+++ b/flux/clusters/homelab/infrastructure/homepage/frontend/src/pages/Home.tsx
@@ -100,6 +100,15 @@ const Home: React.FC = () => {
       'rabbitmq': SiRabbitmq,
       'shield': FaShieldAlt,
       'certification': BiCertification,
+      'pydantic': FaRobot,
+      'logfire': FaRobot,
+      'vertexai': FaCloud,
+      'langchain': FaRobot,
+      'langgraph': FaRocket,
+      'flyte': FaStream,
+      'wandb': FaChartBar,
+      'kamaji': SiKubernetes,
+      'mcp': FaRobot,
     }
     return iconMap[iconName.toLowerCase()] || SiGithub
   }
@@ -263,6 +272,38 @@ const Home: React.FC = () => {
             <div className="skill-tag">
               <SiArgo className="skill-icon" style={{ color: '#326CE5' }} />
               <span>ArgoCD</span>
+            </div>
+            <div className="skill-tag">
+              <FaRobot className="skill-icon" style={{ color: '#FF6B35' }} />
+              <span>Pydantic Logfire</span>
+            </div>
+            <div className="skill-tag">
+              <FaCloud className="skill-icon" style={{ color: '#4285F4' }} />
+              <span>Vertex AI</span>
+            </div>
+            <div className="skill-tag">
+              <FaRobot className="skill-icon" style={{ color: '#1C3C3C' }} />
+              <span>Langchain</span>
+            </div>
+            <div className="skill-tag">
+              <FaRocket className="skill-icon" style={{ color: '#FF6B35' }} />
+              <span>Langgraph</span>
+            </div>
+            <div className="skill-tag">
+              <FaStream className="skill-icon" style={{ color: '#E6522C' }} />
+              <span>Flyte</span>
+            </div>
+            <div className="skill-tag">
+              <FaChartBar className="skill-icon" style={{ color: '#FF6B35' }} />
+              <span>Wandb</span>
+            </div>
+            <div className="skill-tag">
+              <SiKubernetes className="skill-icon" style={{ color: '#326CE5' }} />
+              <span>Kamaji</span>
+            </div>
+            <div className="skill-tag">
+              <FaRobot className="skill-icon" style={{ color: '#00B4D8' }} />
+              <span>MCP-Servers</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 🚀 Add AI Skills to Homepage

This PR adds new AI-related skills to the homepage skills grid section.

### ✨ New Skills Added:
- **Pydantic Logfire** - AI observability and logging platform
- **Vertex AI** - Google Cloud AI/ML platform
- **Langchain** - LLM application framework
- **Langgraph** - LLM workflow orchestration
- **Flyte** - ML workflow orchestration platform
- **Wandb** - ML experiment tracking and monitoring
- **Kamaji** - Kubernetes control plane management
- **MCP-Servers** - Model Context Protocol servers

### 🎨 Implementation Details:
- Added 8 new skill tags to the skills grid with appropriate icons
- Updated iconMap with mappings for the new AI technologies
- Used existing react-icons with consistent styling and colors
- Maintained the same visual design pattern as existing skills

### 🔧 Technical Changes:
- Modified `flux/clusters/homelab/infrastructure/homepage/frontend/src/pages/Home.tsx`
- Added new skill-tag divs to the skills-grid section
- Extended iconMap with new AI technology mappings

### 🎯 Impact:
- Showcases expertise in modern AI/ML infrastructure and tools
- Demonstrates knowledge of LLM frameworks and MLOps platforms
- Maintains visual consistency with existing homepage design

All changes maintain consistency with the existing design system and follow the established patterns.